### PR TITLE
add support for Mastercard bin 2 ranges

### DIFF
--- a/jquery.validate.creditcard2-1.0.1.js
+++ b/jquery.validate.creditcard2-1.0.1.js
@@ -24,8 +24,8 @@ jQuery.validator.addMethod("creditcard2", function(value, element, param) {
 
 	var cards = new Array();
 	cards[0] = { cardName: "Visa", lengths: "13,16", prefixes: "4", checkdigit: true };
-	cards[1] = { cardName: "MasterCard", lengths: "16", prefixes: "51,52,53,54,55", checkdigit: true };
-	cards[2] = { cardName: "DinersClub", lengths: "14,16", prefixes: "305,36,38,54,55,22,23,24,25,26,27", checkdigit: true };
+	cards[1] = { cardName: "MasterCard", lengths: "16", prefixes: "51,52,53,54,55,22,23,24,25,26,27", checkdigit: true };
+	cards[2] = { cardName: "DinersClub", lengths: "14,16", prefixes: "305,36,38,54,55", checkdigit: true };
 	cards[3] = { cardName: "CarteBlanche", lengths: "14", prefixes: "300,301,302,303,304,305", checkdigit: true };
 	cards[4] = { cardName: "AmEx", lengths: "15", prefixes: "34,37", checkdigit: true };
 	cards[5] = { cardName: "Discover", lengths: "16", prefixes: "6011,622,64,65", checkdigit: true };

--- a/jquery.validate.creditcard2-1.0.1.js
+++ b/jquery.validate.creditcard2-1.0.1.js
@@ -25,7 +25,7 @@ jQuery.validator.addMethod("creditcard2", function(value, element, param) {
 	var cards = new Array();
 	cards[0] = { cardName: "Visa", lengths: "13,16", prefixes: "4", checkdigit: true };
 	cards[1] = { cardName: "MasterCard", lengths: "16", prefixes: "51,52,53,54,55", checkdigit: true };
-	cards[2] = { cardName: "DinersClub", lengths: "14,16", prefixes: "305,36,38,54,55", checkdigit: true };
+	cards[2] = { cardName: "DinersClub", lengths: "14,16", prefixes: "305,36,38,54,55,22,23,24,25,26,27", checkdigit: true };
 	cards[3] = { cardName: "CarteBlanche", lengths: "14", prefixes: "300,301,302,303,304,305", checkdigit: true };
 	cards[4] = { cardName: "AmEx", lengths: "15", prefixes: "34,37", checkdigit: true };
 	cards[5] = { cardName: "Discover", lengths: "16", prefixes: "6011,622,64,65", checkdigit: true };


### PR DESCRIPTION
Mastercard started issuing cards with the 2 BIN range from 222100 to 272099 in june of 2017.  These new card numbers would fail the current mastercard validation which only accepts numbers starting 51-55.
adding 22,23,24,25,26,27 as possible prefixes is imprecise, but since there's already overlap between Mastercard and DinersClub (54, 55), it's more precise than that.  